### PR TITLE
fix index into schaler error

### DIFF
--- a/object_detection.py
+++ b/object_detection.py
@@ -14,7 +14,7 @@ class ObjectDetection:
         with open("models/coco.names", "r") as f:
             self.CLASSES = [line.strip() for line in f.readlines()]
 
-        self.OUTPUT_LAYERS = [self.MODEL.getLayerNames()[i[0] - 1] for i in self.MODEL.getUnconnectedOutLayers()]
+        self.OUTPUT_LAYERS = [self.MODEL.getLayerNames()[i - 1] for i in self.MODEL.getUnconnectedOutLayers()]
         self.COLORS = np.random.uniform(0, 255, size=(len(self.CLASSES), 3))
         self.COLORS /= (np.sum(self.COLORS**2, axis=1)**0.5/255)[np.newaxis].T
 


### PR DESCRIPTION
In the object_detection.py, there was an index error because of the code **i[0]**.
This is wrong as it tries to index into a scalar (non-iterable) value.
To make this work, I have removed [0].